### PR TITLE
Update to PostgreSQL 13 and PostGIS 3

### DIFF
--- a/.ackrc
+++ b/.ackrc
@@ -3,3 +3,4 @@
 --ignore-dir=logs
 --ignore-dir=.nyc_output
 --ignore-dir=public
+--ignore-dir=tmp

--- a/.dockerignore
+++ b/.dockerignore
@@ -12,5 +12,6 @@
 /nodemon.json
 /.nyc_output
 /public
+/tmp
 /.tool-versions
 /.vscode

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -149,9 +149,10 @@ When developing locally, you can use `sequelize-cli` directly using [npx][npx],
 for example:
 
 Command                               | Description
-:------------------------------------ | :---------------------------------
+:------------------------------------ | :------------------------------------------------------------------
 `npx sequelize-cli db:migrate`        | Run pending migrations.
 `npm run migrate`                     | *Alias for the previous command.*
+`npm run migrate:wait`                | Wait for the database to be reachable, then run pending migrations.
 `npx sequelize-cli db:migrate:status` | List the status of all migrations.
 
 Migrations can be written in two ways:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
 
   # Database container (PostgreSQL with PostGIS).
   db:
-    image: mdillon/postgis:11-alpine
+    image: postgis/postgis:13-3.1-alpine
     environment:
       POSTGRES_DB: smapshot_v2
       POSTGRES_USER: postgres

--- a/package-lock.json
+++ b/package-lock.json
@@ -11186,12 +11186,12 @@
           "dev": true
         },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "supports-color": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "compose": "docker-compose up --build app",
     "compose:install": "npx cross-env DOCKER_INSTALL_DEPENDENCIES=1 npm run compose",
-    "compose:migrate": "docker-compose build base app && docker-compose run --rm app npm run migrate",
+    "compose:migrate": "docker-compose build base app && docker-compose run --rm app npm run migrate:wait",
     "compose:sequelize-cli": "docker-compose build base app && docker-compose run --rm app npx sequelize-cli",
     "compose:test": "docker-compose build base test_app && docker-compose run --rm test_app",
     "compose:test:coverage": "docker-compose build base test_app && npx cross-env SHOW_OPENAPI_COVERAGE=true docker-compose run --rm test_app npm run test:coverage",
@@ -18,7 +18,8 @@
     "doctoc": "doctoc --notitle --gitlab CHEATSHEET.md DEVELOPMENT.md README.md TODO.md",
     "lint": "eslint app/**/*.js bin/www commands/**/*.js config/**/*.js db/**/*.js spec/**/*.js --fix",
     "lint:watch": "onchange -p 1000 \"app/**/*.js\" \"bin/www\" \"commands/**/*.js\" \"config/**/*.js\" \"db/**/*.js\" \"spec/**/*.js\" -- npm run lint",
-    "migrate": "npm run wait:db && sequelize-cli db:migrate",
+    "migrate": "sequelize-cli db:migrate",
+    "migrate:wait": "npm run wait:db && npm run migrate",
     "nodemon": "nodemon",
     "nodemon:docker": "nodemon --legacy-watch --polling-interval 1000",
     "openapi": "node commands/openapi",
@@ -32,7 +33,7 @@
     "test:coverage:watch": "onchange --delay 500 --exclude \"app/generated/**/*\" --initial --kill \"app/**/*.{js,json,yml}\" \"bin/www\" \"commands/**/*.js\" \"config/**/*.js\" \"locales/*.json\" \"spec/**/*.js\" -- npm run test:coverage",
     "test:debug": "cross-env LOG_LEVEL=silly SHOW_OPENAPI_COVERAGE=true npm test",
     "test:init": "concurrently \"npm run precompile\" \"npm run test:migrate\"",
-    "test:migrate": "cross-env NODE_ENV=test npm run migrate",
+    "test:migrate": "cross-env NODE_ENV=test npm run migrate:wait",
     "test:watch": "onchange --delay 500 --exclude \"app/generated/**/*\" --initial --kill \"app/**/*.{js,json,yml}\" \"bin/www\" \"commands/**/*.js\" \"config/**/*.js\" \"locales/*.json\" \"spec/**/*.js\" -- npm test",
     "wait:db": "node commands/wait-for-the-database.js"
   },


### PR DESCRIPTION
Npm scripts have also been refactored so that the "wait-port" package, which
is a development dependency, is not used when running "npm run migrate"
(which is used in production). The new "npm run migrate:wait" script can
be used in development to both wait for the database and migrate it,
while "npm run migrate" simply triggers the migration without waiting.