### PR TITLE
Fix/initialization

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -20,6 +20,10 @@
 # DB_USER=smapshot
 # DB_PASS=changeme
 
+# PostgresSQL dump path on localhost
+# Change this to adapt with where your dupm file actually is on your machine.
+DUMP_PATH=/path/to/postgresql.dump
+
 # Secret used to sign JWTs. This should be a long random string, e.g. 100
 # characters long.
 JWT_SECRET=changeme

--- a/README.md
+++ b/README.md
@@ -32,12 +32,10 @@ The online documentation is available at https://smapshot.heig-vd.ch/api/v1/docs
 
 * Copy the `.env.sample` file to `.env` and adapt it to your local environment.
 
-  > If you are developing with Docker Compose, you do not need to configure the
-  > database connection, as the database is created and configured for you.
+  > If you are developing with Docker Compose, you do not need to configure the database connection, as the database is created and configured for you.
 * You can download sample images from [the Switch
   drive](https://drive.switch.ch/index.php/apps/files/?dir=/Smapshot/Sample%20Data&fileid=1891746707).
-  Unzip the contents of the `data.zip` file into the `public/data` directory in
-  this repository.
+  Unzip the contents of the `data.zip` file into the `public/data` directory in this repository.
 * Once you have set up the database in the following sections, if you do not
   have a `super_admin` user account (password `super_admin`), you can add one with:
 
@@ -65,8 +63,7 @@ npm run compose:migrate
 
 Command                   | Description
 :------------------------ | :------------------------------------------------------------------
-`npm run compose`         | Start the application and install dependencies the first time.
-`npm run compose:install` | Run `npm install` to install missing/updated dependencies (slower).
+`npm run compose:app`     | Start the application and install dependencies the first time.
 
 Visit http://localhost:1337 once the application has started.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Command                   | Description
 :------------------------ | :------------------------------------------------------------------
 `npm run compose:app`     | Start the application and install dependencies the first time.
 
-Visit http://localhost:1337 once the application has started.
+Visit http://localhost:1337/docs/ once the application has started.
 
 ### Run the automated tests
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The online documentation is available at https://smapshot.heig-vd.ch/api/v1/docs
   drive](https://drive.switch.ch/index.php/apps/files/?dir=/Smapshot/Sample%20Data&fileid=1891746707).
   Unzip the contents of the `data.zip` file into the `public/data` directory in this repository.
 
-* The demo super admin account to be used within the API is as follows:
+* A super admin demo account is created in the database during the intialization. It can be used to login in the API using the following information:
   * first_name: Frank
   * last_name: Dulin
   * email: super_admin@smapshot.ch

--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ The online documentation is available at https://smapshot.heig-vd.ch/api/v1/docs
 * You can download sample images from [the Switch
   drive](https://drive.switch.ch/index.php/apps/files/?dir=/Smapshot/Sample%20Data&fileid=1891746707).
   Unzip the contents of the `data.zip` file into the `public/data` directory in this repository.
-* Once you have set up the database in the following sections, if you do not
-  have a `super_admin` user account (password `super_admin`), you can add one with:
 
-  ```sql
-  INSERT INTO public.users (first_name, last_name, email, username, date_registr, letter, lang, "password", roles, active)
-  VALUES ('Franck', 'Dulin', 'super_admin@smapshot.ch', 'super_admin', now(), TRUE, 'fr','$2b$12$v80JamELNdJnvHyVAQrUZOaIRJJ2BI48vTsZop4s5mgoA9jbcX4Ni','{volunteer,super_admin}',TRUE);
-  ```
+* The demo super admin account to be used within the API is as follows:
+  * first_name: Frank
+  * last_name: Dulin
+  * email: super_admin@smapshot.ch
+  * username: super_admin
+  * password: super_admin
 
 ## Develop with Docker Compose (recommended)
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,22 @@ The online documentation is available at https://smapshot.heig-vd.ch/api/v1/docs
 
 ## Initial setup
 
+### Fetch (or ask for) a database dump
+
+* As root on the production server:
+  * `cp /data/backups/smapshot-backend/smapshot_database_daily/{datetime of the previous day}/smapshot_database_daily.tar /tmp/`
+* As username on your local machine, run the following steps:
+  * `scp {username}@{servername-or-ip}:/tmp/smapshot_database_daily.tar /home/{username}/Download/`
+  * `cd /home/{username}/Download/`
+  * `tar -xvf smapshot_database_daily.tar`
+  * `cd ./smapshot_database_daily/databases/`
+  * `gzip -d PostgreSQL.sql.gz`
+  * `rm /home/{username}/Download/smapshot_database_daily.tar`
+### Set your environment
+
 * Copy the `.env.sample` file to `.env` and adapt it to your local environment.
+  * Especially set up Facebook and Google OAuth credentials.
+  * Set up the `DUMP_FILE` variable to reference the previousely fetched PostgreSQL database dump, e.g. `/home/{username}/Downloads/smapshot_database_daily/databases/PostgreSQL.sql`.
 
   > If you are developing with Docker Compose, you do not need to configure the database connection, as the database is created and configured for you.
 * You can download sample images from [the Switch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ version: "3.8"
 services:
   # Application container (Node.js server).
   app:
+    hostname: app
     build:
       context: .
       dockerfile: Dockerfile.dev
@@ -41,6 +42,7 @@ services:
   # Database container (PostgreSQL with PostGIS).
   db:
     image: postgis/postgis:13-3.1-alpine
+    hostname: db
     environment:
       POSTGRES_DB: smapshot_v2
       POSTGRES_USER: postgres
@@ -60,6 +62,7 @@ services:
   # Vector tiles generation for points container
   vt_generate:
     image: mediacomem/vtmarkersgenerator:2.3.1
+    hostname: vt_generate
     environment:
       # Always connect the application running in this container to the database
       # running in the `db` container. These environment variables take
@@ -85,6 +88,7 @@ services:
   # Serve vector tiles generated from vt_generate container
   vt_serve:
     image: mediacomem/mbtileserver:1.0.0
+    hostname: vt_serve
     environment:
       TILE_DIR: "/tilesets"
       MBTILESERVER_ARGS: "--disable-preview --disable-svc-list"
@@ -100,6 +104,7 @@ services:
 
   # Test application container (Mocha test runner).
   test_app:
+    hostname: test_app
     build:
       context: .
       dockerfile: Dockerfile.test
@@ -132,6 +137,7 @@ services:
   # Test database container (PostgreSQL with PostGIS).
   test_db:
     image: postgis/postgis:13-3.1-alpine
+    hostname: test_db
     environment:
       POSTGRES_DB: smapshot_test
       POSTGRES_USER: postgres
@@ -141,6 +147,7 @@ services:
   # Base image with compile-time and runtime dependencies.
   base:
     image: smapshot/base
+    hostname: base
     build:
       context: .
       dockerfile: Dockerfile.base

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,8 @@ services:
       # Mount a persistent Docker volume into the container so that PostgreSQL
       # data survives container restart.
       - "db_data:/var/lib/postgresql/data"
+      - ./init_db.sh:/docker-entrypoint-initdb.d/11_init_db.sh
+      - "${DUMP_PATH}:/tmp/dump.sql"
 
   # Vector tiles generation for points container
   vt_generate:

--- a/init_db.sh
+++ b/init_db.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+DUMP_FILE="/tmp/dump.sql"
+
+# Create the smapshot role to avoid the following error:
+# psql:/tmp/dump.sql:1814634: ERROR:  role "smapshot" does not exist
+echo "Create role smapshot..."
+psql \
+  -U ${POSTGRES_USER} \
+  -d ${POSTGRES_DB} \
+  -c 'CREATE ROLE smapshot;'
+  #-v ON_ERROR_STOP=1 # this sanity check SHOULD be activated, but the dump is not clean.
+
+echo "Role smapshot successfully created!"
+
+psql \
+  -U "${POSTGRES_USER}" \
+  -d "${POSTGRES_DB}" \
+  -f "/tmp/dump.sql"
+  #-v ON_ERROR_STOP=1 # this sanity check SHOULD be activated, but the dump is not clean.
+
+#rm -rf "${DUMP_FILE}"
+
+echo "Dump ${DUMP_FILE} successfully restored!"

--- a/init_db.sh
+++ b/init_db.sh
@@ -24,3 +24,12 @@ psql \
 #rm -rf "${DUMP_FILE}"
 
 echo "Dump ${DUMP_FILE} successfully restored!"
+
+echo "Creating default user..."
+psql \
+  -U "${POSTGRES_USER}" \
+  -d "${POSTGRES_DB}" \
+  -c "INSERT INTO public.users (first_name, last_name, email, username, date_registr, letter, lang, \"password\", roles, active)
+  VALUES ('Franck', 'Dulin', 'super_admin@smapshot.ch', 'super_admin', now(), TRUE, 'fr','\$2b\$12\$v80JamELNdJnvHyVAQrUZOaIRJJ2BI48vTsZop4s5mgoA9jbcX4Ni','{volunteer,super_admin}',TRUE);"
+
+echo "Default user created successfully!"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "bin": "./bin/www",
   "scripts": {
     "compose:app": "docker-compose up -d --build app",
-    "compose:install": "npx cross-env DOCKER_INSTALL_DEPENDENCIES=1 npm run compose",
     "compose:migrate": "docker-compose build base app && docker-compose run --rm app npm run migrate:wait",
     "compose:sequelize-cli": "docker-compose build base app && docker-compose run --rm app npx sequelize-cli",
     "compose:test": "docker-compose build base test_app && docker-compose run --rm test_app",


### PR DESCRIPTION
* Let docker manage the restore of the database using a new `.sh` initialization script and a new env var to reference the local path of the PostgreSQL dump file.
* Insert the dummy super user in the initialization script.
* Update `packages.json` to remove call to npm `compose` script.
* Update `README.md` accordingly.