### PR TITLE
order problems by most recent date created

### DIFF
--- a/app/api/problems/problems.list.controller.js
+++ b/app/api/problems/problems.list.controller.js
@@ -46,7 +46,7 @@ exports.getList = route(async (req, res) => {
   const problems = await models.problems.findAll({
     attributes: ["id", "date_created", "title", "description", "problem_type_id", "state"],
     where: cleanedWhereProblems,
-    order: [["id"]],
+    order: [["date_created", 'DESC']],
     include: [
       {
         model: models.problems_type,


### PR DESCRIPTION
[issue/522](https://gitlab.com/mediacomem/smapshot/front-end/-/issues/522)


The users owner_id should be applied in the request when not a super_admin


`if (!rootGetters.isSuperAdmin) {
     params.owner_id = rootGetters.userOwnerId;
  }
`

and in the API we add this here

`const whereOwners = { id: inUniqueOrList(req.query.owner_id) };`