### PR TITLE
update footprint request to be sure that the viewshed isn't empty

### DIFF
--- a/app/api/images/images.controller.js
+++ b/app/api/images/images.controller.js
@@ -530,7 +530,7 @@ exports.getFootprint = utils.route(async (req, res) => {
     attributes: [[models.sequelize.literal(
       `
       CASE
-        WHEN geometadatum.viewshed_simple IS NOT NULL
+        WHEN geometadatum.viewshed_simple IS NOT NULL AND ST_AsText(geometadatum.viewshed_simple) != 'MULTIPOLYGON EMPTY'
         THEN ST_AsGeoJson(geometadatum.viewshed_simple, 5, 2)
         WHEN images.viewshed_simple IS NOT NULL
         THEN ST_AsGeoJson(images.viewshed_simple, 5, 2)


### PR DESCRIPTION
Since the introduction of the automatique compilation, when the computation is outside of CH country, we cannot compute the geometadata and the solution provide the 'MULTIPOLYGON EMPTY' result for viewshed_simple. 

Add the check in the query solve the footprint request problem