### PR TITLE
correcting to Geographic distance orderby query

### DIFF
--- a/app/api/images/images.list.controller.js
+++ b/app/api/images/images.list.controller.js
@@ -374,7 +374,12 @@ const getImagesFromPOI = async (req) => {
   const query = req.query;
   const attributes = parseAttributes(query);
   const orderBy = query.sortKey;
-  const orderByNearest = models.sequelize.literal(`images.location <-> st_setsrid(ST_makepoint(${query.longitude}, ${query.latitude}), 4326)`);
+  const orderByNearest = models.sequelize.literal(`
+    ST_Distance(
+      CAST(images.location AS GEOGRAPHY),
+      CAST(ST_SetSRID(ST_MakePoint(${query.POI_longitude}, ${query.POI_latitude}), 4326) AS GEOGRAPHY)
+    )
+  `);
 
   let whereClauses = [];
 
@@ -476,7 +481,7 @@ const getImagesFromPOI = async (req) => {
     subQuery: false,
     attributes: attributes,
     where: { [Op.and]: whereClauses },
-    order: orderBy === 'distance' ? orderByNearest : (orderBy === 'title' ? [['title']] : [['date_shot_min']]),
+    order: orderBy === 'distance' ? [orderByNearest] : (orderBy === 'title' ? [['title']] : [['date_shot_min']]),
     limit: query.limit || 30,
     offset: query.offset || 0,
   };


### PR DESCRIPTION
following feedback from the owner at BCUF for the findSpot feature. Check if we could order image by camera distance to the point clicked on the map?

Change from Euclidean (flat) to Geographic Distance compare. Now the images order is greatly improved starting with the closest to the clicked point on map.