### PR TITLE
including image_type to generated tiles attributes

### DIFF
--- a/docker/vt_generate/tasks.yml
+++ b/docker/vt_generate/tasks.yml
@@ -3,7 +3,7 @@ tasks:
   visit:
     channelName: "update_vt_visit"
     sql: "
-      SELECT images.id, owner_id, collection_id, ST_Force2D(ST_SnapToGrid(geolocalisations.location, 0.0001)) AS geom,
+      SELECT images.id, images.view_type, owner_id, collection_id, ST_Force2D(ST_SnapToGrid(geolocalisations.location, 0.0001)) AS geom,
       (CASE
           WHEN date_shot IS NOT NULL
           THEN to_char(date(date_shot),'yyyymmdd')::int


### PR DESCRIPTION
I would like to test this in Beta as locally I cannot get the vt tiles on localhost 3005, However with this change I can see that viewtype is added to the output/visit.mbtiles and output/tmp/visit.geojson

together with the changes on the fontend ->\mixins\ViewerMapExplorer.js this should work to filter on visit mode by view_type

```
...(!this.modeContribute
            ? [['in', ['get', 'view_type'], ['literal', filters.view_type]]]
            : []),
```