### PR TITLE
adding index on location cast to geography for getImagesFromPOI

### DIFF
--- a/app/api/images/images.list.controller.js
+++ b/app/api/images/images.list.controller.js
@@ -1,9 +1,9 @@
 const Sequelize = require("sequelize");
-const { intersection } = require('lodash');
+const { intersection } = require("lodash");
 
 const models = require("../../models");
-const { userHasRole } = require('../../utils/authorization');
-const { authorizationError } = require('../../utils/errors');
+const { userHasRole } = require("../../utils/authorization");
+const { authorizationError } = require("../../utils/errors");
 const utils = require("../../utils/express");
 const {
   inUniqueOrList,
@@ -12,17 +12,35 @@ const {
   wktFormatter,
   iLikeFormatter,
   cleanProp,
-  toUniqueArray
+  toUniqueArray,
 } = require("../../utils/params");
-const { getOwnerScope } = require('./images.utils');
-const mediaUtils = require('../../utils/media');
+const { getOwnerScope } = require("./images.utils");
+const mediaUtils = require("../../utils/media");
 
 const Op = Sequelize.Op;
 
 const parseAttributes = (query) => {
-  const basic_attributes = ["id", "original_id", "collection_id", "owner_id", "title", "is_published", "state", "date_georef", "height", "width", "iiif_data"]
-  const longitude = [models.sequelize.literal("ST_X(ST_SnapToGrid(location, 0.0001))"), "longitude"];
-  const latitude = [models.sequelize.literal("ST_Y(ST_SnapToGrid(location, 0.0001))"), "latitude"];
+  const basic_attributes = [
+    "id",
+    "original_id",
+    "collection_id",
+    "owner_id",
+    "title",
+    "is_published",
+    "state",
+    "date_georef",
+    "height",
+    "width",
+    "iiif_data",
+  ];
+  const longitude = [
+    models.sequelize.literal("ST_X(ST_SnapToGrid(location, 0.0001))"),
+    "longitude",
+  ];
+  const latitude = [
+    models.sequelize.literal("ST_Y(ST_SnapToGrid(location, 0.0001))"),
+    "latitude",
+  ];
   const date_shot_min = [
     models.sequelize.literal(
       `(case
@@ -32,7 +50,7 @@ const parseAttributes = (query) => {
         end)
         `
     ),
-    "date_shot_min"
+    "date_shot_min",
   ];
   const date_shot_max = [
     models.sequelize.literal(
@@ -42,7 +60,7 @@ const parseAttributes = (query) => {
         else date(date_shot_max)::TEXT
         end)`
     ),
-    "date_shot_max"
+    "date_shot_max",
   ];
 
   const default_attributes = [
@@ -50,7 +68,7 @@ const parseAttributes = (query) => {
     date_shot_min,
     date_shot_max,
     longitude,
-    latitude
+    latitude,
   ];
 
   if (!query.attributes) {
@@ -58,20 +76,20 @@ const parseAttributes = (query) => {
   }
 
   let attributes = intersection(query.attributes, basic_attributes);
-  if (query.attributes.includes('longitude')) {
+  if (query.attributes.includes("longitude")) {
     attributes.push(longitude);
   }
-  if (query.attributes.includes('latitude')) {
+  if (query.attributes.includes("latitude")) {
     attributes.push(latitude);
   }
-  if (query.attributes.includes('date_shot_min')) {
+  if (query.attributes.includes("date_shot_min")) {
     attributes.push(date_shot_min);
   }
-  if (query.attributes.includes('date_shot_max')) {
+  if (query.attributes.includes("date_shot_max")) {
     attributes.push(date_shot_max);
   }
   return attributes;
-}
+};
 
 const getImages = async (req, orderkey, count = true) => {
   const query = req.query;
@@ -80,18 +98,24 @@ const getImages = async (req, orderkey, count = true) => {
   const orderBy = orderkey ? orderkey : query.sortKey;
   let whereClauses = [];
 
-  const states = query.state ? query.state : ['waiting_validation', 'validated'];
+  const states = query.state
+    ? query.state
+    : ["waiting_validation", "validated"];
   whereClauses.push({ state: inUniqueOrList(states) });
 
-  const isGeoref = states.some(state => ['waiting_validation', 'validated'].includes(state));
+  const isGeoref = states.some((state) =>
+    ["waiting_validation", "validated"].includes(state)
+  );
 
   switch (query.publish_state) {
-    case 'published':
+    case "published":
       whereClauses.push({ is_published: true });
       break;
-    case 'unpublished': {
-      if (!userHasRole(req, 'owner_validator', 'owner_admin', 'super_admin')) {
-        throw authorizationError('Unpublished images can only be accessed by respective owners or super administrators');
+    case "unpublished": {
+      if (!userHasRole(req, "owner_validator", "owner_admin", "super_admin")) {
+        throw authorizationError(
+          "Unpublished images can only be accessed by respective owners or super administrators"
+        );
       }
       const { where: scopeOwner } = getOwnerScope(req);
       // retrieve only unpublished images
@@ -100,21 +124,20 @@ const getImages = async (req, orderkey, count = true) => {
       whereClauses.push(scopeOwner);
       break;
     }
-    case 'all': {
+    case "all": {
       const { where: scopeOwner } = getOwnerScope(req);
-      if (!userHasRole(req, 'owner_validator', 'owner_admin', 'super_admin')) {
-        throw authorizationError('Unpublished images can only be accessed by respective owners or super administrators');
+      if (!userHasRole(req, "owner_validator", "owner_admin", "super_admin")) {
+        throw authorizationError(
+          "Unpublished images can only be accessed by respective owners or super administrators"
+        );
       }
-      if (userHasRole(req, 'super_admin')) {
+      if (userHasRole(req, "super_admin")) {
         // no restriction on is_published - get all images whatever status
       } else {
         // get all published images
         // + unpublished restricted to current owner
         whereClauses.push({
-          [Op.or]: [
-            { is_published: true },
-            scopeOwner
-          ]
+          [Op.or]: [{ is_published: true }, scopeOwner],
         });
       }
       break;
@@ -145,8 +168,8 @@ const getImages = async (req, orderkey, count = true) => {
       [Op.or]: {
         original_id: iLikeFormatter(query.keyword),
         title: iLikeFormatter(query.keyword),
-        caption: iLikeFormatter(query.keyword)
-      }
+        caption: iLikeFormatter(query.keyword),
+      },
     });
   }
 
@@ -155,7 +178,9 @@ const getImages = async (req, orderkey, count = true) => {
   }
 
   if (query.place_names) {
-    whereClauses.push({ geotags_array: containsUniqueOrList(query.place_names) });
+    whereClauses.push({
+      geotags_array: containsUniqueOrList(query.place_names),
+    });
   }
 
   if (query.date_shot_min || query.date_shot_max) {
@@ -166,7 +191,7 @@ const getImages = async (req, orderkey, count = true) => {
           [Op.and]: {
             [Op.not]: null,
             [Op.gte]: query.date_shot_min,
-            [Op.lte]: query.date_shot_max
+            [Op.lte]: query.date_shot_max,
           },
         },
         // Range of dates
@@ -175,18 +200,18 @@ const getImages = async (req, orderkey, count = true) => {
             [Op.and]: {
               [Op.not]: null,
               [Op.gte]: query.date_shot_min,
-              [Op.lte]: query.date_shot_max
-            }
+              [Op.lte]: query.date_shot_max,
+            },
           },
           date_shot_max: {
             [Op.and]: {
               [Op.not]: null,
               [Op.gte]: query.date_shot_min,
-              [Op.lte]: query.date_shot_max
-            }
-          }
-        }
-      }
+              [Op.lte]: query.date_shot_max,
+            },
+          },
+        },
+      },
     });
   }
 
@@ -194,14 +219,14 @@ const getImages = async (req, orderkey, count = true) => {
     whereClauses.push({
       date_inserted: {
         [Op.gte]: query.date_inserted_min,
-      }
+      },
     });
   }
   if (query.date_inserted_max) {
     whereClauses.push({
       date_inserted: {
-        [Op.lte]: query.date_inserted_max
-      }
+        [Op.lte]: query.date_inserted_max,
+      },
     });
   }
 
@@ -209,14 +234,14 @@ const getImages = async (req, orderkey, count = true) => {
     whereClauses.push({
       date_georef: {
         [Op.gte]: query.date_georef_min,
-      }
+      },
     });
   }
   if (query.date_georef_max) {
     whereClauses.push({
       date_inserted: {
-        [Op.date_georef]: query.date_georef_max
-      }
+        [Op.date_georef]: query.date_georef_max,
+      },
     });
   }
 
@@ -224,14 +249,14 @@ const getImages = async (req, orderkey, count = true) => {
     whereClauses.push({
       date_validated: {
         [Op.gte]: query.date_validated_min,
-      }
+      },
     });
   }
   if (query.date_validated_max) {
     whereClauses.push({
       date_validated: {
-        [Op.lte]: query.date_validated_max
-      }
+        [Op.lte]: query.date_validated_max,
+      },
     });
   }
 
@@ -242,7 +267,7 @@ const getImages = async (req, orderkey, count = true) => {
   if (isGeoref) {
     if (query.bbox) {
       whereClauses.push({
-        location: bboxFormater(query.bbox)
+        location: bboxFormater(query.bbox),
       });
     }
     if (query.wkt_roi) {
@@ -251,17 +276,18 @@ const getImages = async (req, orderkey, count = true) => {
           query.wkt_roi,
           query.intersect_location || false,
           query.intersect_footprint || false
-        )
+        ),
       });
     }
   }
 
-
   // Filter locked images
   if (query.only_unlocked) {
-    whereClauses.push(models.sequelize.literal(
-      "last_start IS NULL OR (EXTRACT(EPOCH FROM now())-EXTRACT(EPOCH FROM last_start))/60 >= 240"
-    ));
+    whereClauses.push(
+      models.sequelize.literal(
+        "last_start IS NULL OR (EXTRACT(EPOCH FROM now())-EXTRACT(EPOCH FROM last_start))/60 >= 240"
+      )
+    );
   }
 
   const today = new Date();
@@ -274,9 +300,9 @@ const getImages = async (req, orderkey, count = true) => {
     where: {
       date_publi: {
         [Op.not]: null,
-        [Op.lte]: today // future publish date is not yet published
+        [Op.lte]: today, // future publish date is not yet published
       },
-    }
+    },
   };
 
   const randomOrder = models.sequelize.literal("random()");
@@ -284,21 +310,19 @@ const getImages = async (req, orderkey, count = true) => {
   // findAll returns an array where findAndCountAll returns object {rows, count}
   const response = {
     rows: [],
-    count: null
-  }
+    count: null,
+  };
 
   if (!isGeoref) {
-    let whereClauseApriori = {}
+    let whereClauseApriori = {};
     let includeOption = null;
 
     if (query.bbox) {
       whereClauseApriori = {
         geom: {
-          [Op.and]: [
-            bboxFormater(query.bbox || false)
-          ]
-        }
-      }
+          [Op.and]: [bboxFormater(query.bbox || false)],
+        },
+      };
     }
 
     let orderByApriori;
@@ -306,7 +330,9 @@ const getImages = async (req, orderkey, count = true) => {
     if (!query.longitude || !query.latitude) {
       orderByApriori = undefined;
     } else {
-      orderByApriori = models.sequelize.literal(`apriori_locations.geom <-> st_setsrid(ST_makepoint(${query.longitude}, ${query.latitude}), 4326)`);
+      orderByApriori = models.sequelize.literal(
+        `apriori_locations.geom <-> st_setsrid(ST_makepoint(${query.longitude}, ${query.latitude}), 4326)`
+      );
     }
 
     const orderById = [["id"]];
@@ -316,14 +342,14 @@ const getImages = async (req, orderkey, count = true) => {
         attributes: [
           [models.sequelize.literal("ST_X(geom)"), "longitude"],
           [models.sequelize.literal("ST_Y(geom)"), "latitude"],
-          "exact"
+          "exact",
         ],
         where: whereClauseApriori,
         required: true,
         duplicating: false,
-        order: orderBy === 'distance' ? orderByApriori : undefined
+        order: orderBy === "distance" ? orderByApriori : undefined,
       },
-      includeCollectionFilter
+      includeCollectionFilter,
     ];
     const sequelizeQuery = {
       subQuery: false,
@@ -331,8 +357,13 @@ const getImages = async (req, orderkey, count = true) => {
       limit: query.limit || 30,
       offset: query.offset || 0,
       where: { [Op.and]: whereClauses },
-      order: orderBy === 'id' ? orderById : (orderBy === 'random' ? randomOrder : orderByApriori),
-      include: includeOption
+      order:
+        orderBy === "id"
+          ? orderById
+          : orderBy === "random"
+          ? randomOrder
+          : orderByApriori,
+      include: includeOption,
     };
     if (count) {
       response.rows = await models.images.findAll(sequelizeQuery);
@@ -340,16 +371,18 @@ const getImages = async (req, orderkey, count = true) => {
       const countPromise = await models.images.count({
         where: { [Op.and]: whereClauses },
         include: includeOption,
-        distinct: 'images.id'
+        distinct: "images.id",
       });
-      response.count = countPromise
+      response.count = countPromise;
       return response;
     } else {
       response.rows = await models.images.findAll(sequelizeQuery);
       return response;
     }
   } else {
-    const orderByNearest = models.sequelize.literal(`images.location <-> st_setsrid(ST_makepoint(${query.longitude}, ${query.latitude}), 4326)`);
+    const orderByNearest = models.sequelize.literal(
+      `images.location <-> st_setsrid(ST_makepoint(${query.longitude}, ${query.latitude}), 4326)`
+    );
     const orderById = [["id"]];
     const sequelizeQuery = {
       subQuery: false,
@@ -357,11 +390,18 @@ const getImages = async (req, orderkey, count = true) => {
       limit: query.limit || 30,
       offset: query.offset || 0,
       where: { [Op.and]: whereClauses },
-      order: orderBy === 'distance' ? orderByNearest : (orderBy === 'random' ? randomOrder : orderById),
-      include: [includeCollectionFilter]
+      order:
+        orderBy === "distance"
+          ? orderByNearest
+          : orderBy === "random"
+          ? randomOrder
+          : orderById,
+      include: [includeCollectionFilter],
     };
     if (count) {
-      const imagesAndCount = await models.images.findAndCountAll(sequelizeQuery);
+      const imagesAndCount = await models.images.findAndCountAll(
+        sequelizeQuery
+      );
       return imagesAndCount;
     } else {
       response.rows = await models.images.findAll(sequelizeQuery);
@@ -374,12 +414,24 @@ const getImagesFromPOI = async (req) => {
   const query = req.query;
   const attributes = parseAttributes(query);
   const orderBy = query.sortKey;
-  const orderByNearest = models.sequelize.literal(`
-    ST_Distance(
-      CAST(images.location AS GEOGRAPHY),
-      CAST(ST_SetSRID(ST_MakePoint(${query.POI_longitude}, ${query.POI_latitude}), 4326) AS GEOGRAPHY)
-    )
-  `);
+  const poiLocationGeo = Sequelize.cast(
+    Sequelize.fn(
+      "ST_SetSRID",
+      Sequelize.fn("ST_MakePoint", query.POI_longitude, query.POI_latitude),
+      4326
+    ),
+    "geography"
+  );
+  const imageLocationGeo = Sequelize.cast(
+    Sequelize.col("images.location"),
+    "geography"
+  );
+  const distanceExpr = Sequelize.fn(
+    "ST_Distance",
+    imageLocationGeo,
+    poiLocationGeo
+  );
+  const orderByNearest = distanceExpr;
 
   let whereClauses = [];
 
@@ -396,13 +448,15 @@ const getImagesFromPOI = async (req) => {
       [Op.or]: {
         original_id: iLikeFormatter(query.keyword),
         title: iLikeFormatter(query.keyword),
-        caption: iLikeFormatter(query.keyword)
-      }
+        caption: iLikeFormatter(query.keyword),
+      },
     });
   }
 
   if (query.place_names) {
-    whereClauses.push({ geotags_array: containsUniqueOrList(query.place_names) });
+    whereClauses.push({
+      geotags_array: containsUniqueOrList(query.place_names),
+    });
   }
 
   if (query.date_shot_min || query.date_shot_max) {
@@ -413,7 +467,7 @@ const getImagesFromPOI = async (req) => {
           [Op.and]: {
             [Op.not]: null,
             [Op.gte]: query.date_shot_min,
-            [Op.lte]: query.date_shot_max
+            [Op.lte]: query.date_shot_max,
           },
         },
         // Range of dates
@@ -422,18 +476,18 @@ const getImagesFromPOI = async (req) => {
             [Op.and]: {
               [Op.not]: null,
               [Op.gte]: query.date_shot_min,
-              [Op.lte]: query.date_shot_max
-            }
+              [Op.lte]: query.date_shot_max,
+            },
           },
           date_shot_max: {
             [Op.and]: {
               [Op.not]: null,
               [Op.gte]: query.date_shot_min,
-              [Op.lte]: query.date_shot_max
-            }
-          }
-        }
-      }
+              [Op.lte]: query.date_shot_max,
+            },
+          },
+        },
+      },
     });
   }
 
@@ -453,35 +507,32 @@ const getImagesFromPOI = async (req) => {
   whereClauses.push(
     Sequelize.where(
       Sequelize.fn(
-        'ST_Distance',
-        Sequelize.cast(
-          Sequelize.fn('ST_SetSRID', Sequelize.fn('ST_MakePoint', query.POI_longitude, query.POI_latitude), 4326),
-          'geography'
-        ),
-        Sequelize.cast(
-          Sequelize.col('images.location'),
-          'geography'
-        )
+        "ST_DWithin",
+        imageLocationGeo,
+        poiLocationGeo,
+        query.POI_MaxDistance
       ),
-      { // Distance in meters (20 km = 20000 meters)
-        [Op.and]: [
-          { [Op.lte]: query.POI_MaxDistance }, // Distance less than or equal to query.distance
-          { [Op.gt]: 4 } // To avoid unwanted images locatated on point ie looking away from point
-        ]
-      }
-    ),
+      true
+    )
   );
 
   const sequelizeQuery = {
-    include: [{
-      model: models.geometadata,
-      required: true, // Ensure that only images with geometadata are retrieved
-      attributes: [], // Exclude geometadata attributes from the result, we only need it for the join
-    }],
+    include: [
+      {
+        model: models.geometadata,
+        required: true, // Ensure that only images with geometadata are retrieved
+        attributes: [], // Exclude geometadata attributes from the result, we only need it for the join
+      },
+    ],
     subQuery: false,
     attributes: attributes,
     where: { [Op.and]: whereClauses },
-    order: orderBy === 'distance' ? [orderByNearest] : (orderBy === 'title' ? [['title']] : [['date_shot_min']]),
+    order:
+      orderBy === "distance"
+        ? [orderByNearest]
+        : orderBy === "title"
+        ? [["title"]]
+        : [["date_shot_min"]],
     limit: query.limit || 30,
     offset: query.offset || 0,
   };
@@ -499,9 +550,14 @@ exports.getList = utils.route(async (req, res) => {
     images = await getImages(req);
   }
   //Build media
-  if (!req.query.attributes || req.query.attributes.includes('media')) { //only return media if no specific attributes requested or if media requested
+  if (!req.query.attributes || req.query.attributes.includes("media")) {
+    //only return media if no specific attributes requested or if media requested
     if (images.rows) {
-      await mediaUtils.setListImageUrl(images.rows, /* image_width */ 200, /* image_height */ null);
+      await mediaUtils.setListImageUrl(
+        images.rows,
+        /* image_width */ 200,
+        /* image_height */ null
+      );
     }
     images.rows.forEach((image) => {
       delete image.dataValues.iiif_data;
@@ -513,29 +569,39 @@ exports.getList = utils.route(async (req, res) => {
 
 exports.getListId = utils.route(async (req, res) => {
   req.query = { ...req.query, attributes: ["id"] };
-  const images = await getImages(req, /*orderBy*/ 'id', /*count*/ false);
+  const images = await getImages(req, /*orderBy*/ "id", /*count*/ false);
   // Send flattened objects
-  res.status(200).send(images.rows.map(obj => obj.id));
+  res.status(200).send(images.rows.map((obj) => obj.id));
 });
 
 exports.getListMetadata = utils.route(async (req, res) => {
   let ownerIds;
   const user = req.user;
-  const requestedOwnerIds = req.query.owner_id ? toUniqueArray(req.query.owner_id) : undefined;
+  const requestedOwnerIds = req.query.owner_id
+    ? toUniqueArray(req.query.owner_id)
+    : undefined;
   if (user.isSuperAdmin()) {
     // A super administrator can request image metadata for any owner (or access
     // all images).
     ownerIds = requestedOwnerIds;
-  } else if (user.hasRole('owner_admin') || user.hasRole('owner_validator')) {
+  } else if (user.hasRole("owner_admin") || user.hasRole("owner_validator")) {
     // An owner administrator or validator can only request image metadata for
     // their owner.
     const accessibleOwnerIds = [user.owner_id];
-    ownerIds = requestedOwnerIds ? intersection(requestedOwnerIds, accessibleOwnerIds) : accessibleOwnerIds;
+    ownerIds = requestedOwnerIds
+      ? intersection(requestedOwnerIds, accessibleOwnerIds)
+      : accessibleOwnerIds;
     if (requestedOwnerIds && ownerIds.length !== requestedOwnerIds.length) {
-      throw authorizationError('An owner validator or administrator can only access metadata for images linked to the same owner');
+      throw authorizationError(
+        "An owner validator or administrator can only access metadata for images linked to the same owner"
+      );
     }
   } else {
-    throw new Error(`Cannot determine owner scope for user ${user.id} with unsupported role(s) ${user.roles.join(', ')}`);
+    throw new Error(
+      `Cannot determine owner scope for user ${
+        user.id
+      } with unsupported role(s) ${user.roles.join(", ")}`
+    );
   }
 
   const whereImages = {
@@ -545,8 +611,8 @@ exports.getListMetadata = utils.route(async (req, res) => {
     original_id: inUniqueOrList(req.query.original_id),
     date_validated: {
       [Op.gte]: req.query.date_validated_min,
-      [Op.lte]: req.query.date_validated_max
-    }
+      [Op.lte]: req.query.date_validated_max,
+    },
   };
 
   const cleanedWhere = cleanProp(whereImages);
@@ -556,39 +622,52 @@ exports.getListMetadata = utils.route(async (req, res) => {
     {
       model: models.geolocalisations,
       attributes: [
-        [models.sequelize.literal("st_X(geolocalisation.location)"), "longitude"],
-        [models.sequelize.literal("st_Y(geolocalisation.location)"), "latitude"],
-        [models.sequelize.literal("st_Z(geolocalisation.location)"), "altitude"],
+        [
+          models.sequelize.literal("st_X(geolocalisation.location)"),
+          "longitude",
+        ],
+        [
+          models.sequelize.literal("st_Y(geolocalisation.location)"),
+          "latitude",
+        ],
+        [
+          models.sequelize.literal("st_Z(geolocalisation.location)"),
+          "altitude",
+        ],
         "azimuth",
         "tilt",
         "roll",
         "focal",
-        [models.sequelize.literal("st_AsText(geolocalisation.location)"), "point"],
-        [models.sequelize.literal("st_AsText(geolocalisation.footprint)"), "footprint"],
+        [
+          models.sequelize.literal("st_AsText(geolocalisation.location)"),
+          "point",
+        ],
+        [
+          models.sequelize.literal("st_AsText(geolocalisation.footprint)"),
+          "footprint",
+        ],
       ],
       where: {
         [Op.and]: [
           {
-            [Op.or]: [
-              {state: 'validated'},
-              {state: 'improved'}
-            ]
+            [Op.or]: [{ state: "validated" }, { state: "improved" }],
           },
           {
-            id: {[Op.col]: 'images.geolocalisation_id'}
-          }
-        ]
+            id: { [Op.col]: "images.geolocalisation_id" },
+          },
+        ],
       },
-      required: false
+      required: false,
     },
     {
       model: models.geometadata,
       attributes: [],
-      required: false
-    }];
+      required: false,
+    },
+  ];
 
   const countTotal = await models.images.count({
-    where: cleanedWhere
+    where: cleanedWhere,
   });
 
   const attributes = [
@@ -602,12 +681,18 @@ exports.getListMetadata = utils.route(async (req, res) => {
     "link",
     "is_published",
     [models.sequelize.literal("ST_X(images.location)"), "longitude"],
-    [models.sequelize.literal("ST_Y(images.location)"), "latitude"]
+    [models.sequelize.literal("ST_Y(images.location)"), "latitude"],
   ];
 
   if (req.query.geolocalisation) {
-    attributes.push([Sequelize.col('geometadatum.toponyms_array'), 'geotags_array'])
-    attributes.push([Sequelize.col('geometadatum.toponyms_json'), 'geotags_json'])
+    attributes.push([
+      Sequelize.col("geometadatum.toponyms_array"),
+      "geotags_array",
+    ]);
+    attributes.push([
+      Sequelize.col("geometadatum.toponyms_json"),
+      "geotags_json",
+    ]);
   }
 
   const images = await models.images.findAll({
@@ -616,10 +701,10 @@ exports.getListMetadata = utils.route(async (req, res) => {
     offset: req.query.offset || 0,
     where: cleanedWhere,
     order: [["id"]],
-    include: req.query.geolocalisation ? includeGeoloc : null
+    include: req.query.geolocalisation ? includeGeoloc : null,
   });
 
-  res.header('Total-Items', countTotal).status(200).send(images);
+  res.header("Total-Items", countTotal).status(200).send(images);
 });
 
 exports.getStats = utils.route(async (req, res) => {
@@ -630,69 +715,64 @@ exports.getStats = utils.route(async (req, res) => {
     validator_id: inUniqueOrList(req.query.validator_id),
     user_id: inUniqueOrList(req.query.user_id),
     ...(req.query.date_shot_min || req.query.date_shot_max
-      ?
-      {
-        // Single date
-        [Op.or]: {
-          date_shot: {
+      ? {
+          // Single date
+          [Op.or]: {
+            date_shot: {
+              [Op.and]: {
+                [Op.not]: null,
+                [Op.gte]: req.query.date_shot_min,
+                [Op.lte]: req.query.date_shot_max,
+              },
+            },
+            // Range of dates
             [Op.and]: {
-              [Op.not]: null,
-              [Op.gte]: req.query.date_shot_min,
-              [Op.lte]: req.query.date_shot_max
+              date_shot_min: {
+                [Op.and]: {
+                  [Op.not]: null,
+                  [Op.gte]: req.query.date_shot_min,
+                  [Op.lte]: req.query.date_shot_max,
+                },
+              },
+              date_shot_max: {
+                [Op.and]: {
+                  [Op.not]: null,
+                  [Op.gte]: req.query.date_shot_min,
+                  [Op.lte]: req.query.date_shot_max,
+                },
+              },
             },
           },
-          // Range of dates
-          [Op.and]: {
-            date_shot_min: {
-              [Op.and]: {
-                [Op.not]: null,
-                [Op.gte]: req.query.date_shot_min,
-                [Op.lte]: req.query.date_shot_max
-              }
-            },
-            date_shot_max: {
-              [Op.and]: {
-                [Op.not]: null,
-                [Op.gte]: req.query.date_shot_min,
-                [Op.lte]: req.query.date_shot_max
-              }
-            }
-          }
         }
-      }
       : {}),
     date_inserted: {
       [Op.gte]: req.query.date_inserted_min,
-      [Op.lte]: req.query.date_inserted_max
+      [Op.lte]: req.query.date_inserted_max,
     },
     date_georef: {
       [Op.gte]: req.query.date_georef_min,
-      [Op.lte]: req.query.date_georef_max
+      [Op.lte]: req.query.date_georef_max,
     },
     date_validated: {
       [Op.gte]: req.query.date_validated_min,
-      [Op.lte]: req.query.date_validated_max
-    }
+      [Op.lte]: req.query.date_validated_max,
+    },
   };
 
   const cleanedWhere = cleanProp(whereImages);
 
   const queryPromise = models.images.findAll({
-    attributes: [
-      "state",
-      [models.sequelize.fn("COUNT", "id"), "count"]
-    ],
+    attributes: ["state", [models.sequelize.fn("COUNT", "id"), "count"]],
     where: cleanedWhere,
-    group: ["state"]
+    group: ["state"],
   });
 
   const result = await utils.handlePromise(queryPromise, {
-    message: "Images cannot be retrieved."
+    message: "Images cannot be retrieved.",
   });
 
   res.status(200).send({
     count: result.reduce((a, b) => a + b.get({ plain: true }).count, 0),
-    rows: result
+    rows: result,
   });
 });
-

--- a/app/api/images/images.list.controller.js
+++ b/app/api/images/images.list.controller.js
@@ -1,10 +1,10 @@
-const Sequelize = require("sequelize");
-const { intersection } = require("lodash");
+const Sequelize = require('sequelize');
+const { intersection } = require('lodash');
 
-const models = require("../../models");
-const { userHasRole } = require("../../utils/authorization");
-const { authorizationError } = require("../../utils/errors");
-const utils = require("../../utils/express");
+const models = require('../../models');
+const { userHasRole } = require('../../utils/authorization');
+const { authorizationError } = require('../../utils/errors');
+const utils = require('../../utils/express');
 const {
   inUniqueOrList,
   containsUniqueOrList,
@@ -13,33 +13,33 @@ const {
   iLikeFormatter,
   cleanProp,
   toUniqueArray,
-} = require("../../utils/params");
-const { getOwnerScope } = require("./images.utils");
-const mediaUtils = require("../../utils/media");
+} = require('../../utils/params');
+const { getOwnerScope } = require('./images.utils');
+const mediaUtils = require('../../utils/media');
 
 const Op = Sequelize.Op;
 
 const parseAttributes = (query) => {
   const basic_attributes = [
-    "id",
-    "original_id",
-    "collection_id",
-    "owner_id",
-    "title",
-    "is_published",
-    "state",
-    "date_georef",
-    "height",
-    "width",
-    "iiif_data",
+    'id',
+    'original_id',
+    'collection_id',
+    'owner_id',
+    'title',
+    'is_published',
+    'state',
+    'date_georef',
+    'height',
+    'width',
+    'iiif_data',
   ];
   const longitude = [
-    models.sequelize.literal("ST_X(ST_SnapToGrid(location, 0.0001))"),
-    "longitude",
+    models.sequelize.literal('ST_X(ST_SnapToGrid(location, 0.0001))'),
+    'longitude',
   ];
   const latitude = [
-    models.sequelize.literal("ST_Y(ST_SnapToGrid(location, 0.0001))"),
-    "latitude",
+    models.sequelize.literal('ST_Y(ST_SnapToGrid(location, 0.0001))'),
+    'latitude',
   ];
   const date_shot_min = [
     models.sequelize.literal(
@@ -50,7 +50,7 @@ const parseAttributes = (query) => {
         end)
         `
     ),
-    "date_shot_min",
+    'date_shot_min',
   ];
   const date_shot_max = [
     models.sequelize.literal(
@@ -60,7 +60,7 @@ const parseAttributes = (query) => {
         else date(date_shot_max)::TEXT
         end)`
     ),
-    "date_shot_max",
+    'date_shot_max',
   ];
 
   const default_attributes = [
@@ -76,16 +76,16 @@ const parseAttributes = (query) => {
   }
 
   let attributes = intersection(query.attributes, basic_attributes);
-  if (query.attributes.includes("longitude")) {
+  if (query.attributes.includes('longitude')) {
     attributes.push(longitude);
   }
-  if (query.attributes.includes("latitude")) {
+  if (query.attributes.includes('latitude')) {
     attributes.push(latitude);
   }
-  if (query.attributes.includes("date_shot_min")) {
+  if (query.attributes.includes('date_shot_min')) {
     attributes.push(date_shot_min);
   }
-  if (query.attributes.includes("date_shot_max")) {
+  if (query.attributes.includes('date_shot_max')) {
     attributes.push(date_shot_max);
   }
   return attributes;
@@ -100,21 +100,21 @@ const getImages = async (req, orderkey, count = true) => {
 
   const states = query.state
     ? query.state
-    : ["waiting_validation", "validated"];
+    : ['waiting_validation', 'validated'];
   whereClauses.push({ state: inUniqueOrList(states) });
 
   const isGeoref = states.some((state) =>
-    ["waiting_validation", "validated"].includes(state)
+    ['waiting_validation', 'validated'].includes(state)
   );
 
   switch (query.publish_state) {
-    case "published":
+    case 'published':
       whereClauses.push({ is_published: true });
       break;
-    case "unpublished": {
-      if (!userHasRole(req, "owner_validator", "owner_admin", "super_admin")) {
+    case 'unpublished': {
+      if (!userHasRole(req, 'owner_validator', 'owner_admin', 'super_admin')) {
         throw authorizationError(
-          "Unpublished images can only be accessed by respective owners or super administrators"
+          'Unpublished images can only be accessed by respective owners or super administrators'
         );
       }
       const { where: scopeOwner } = getOwnerScope(req);
@@ -124,14 +124,14 @@ const getImages = async (req, orderkey, count = true) => {
       whereClauses.push(scopeOwner);
       break;
     }
-    case "all": {
+    case 'all': {
       const { where: scopeOwner } = getOwnerScope(req);
-      if (!userHasRole(req, "owner_validator", "owner_admin", "super_admin")) {
+      if (!userHasRole(req, 'owner_validator', 'owner_admin', 'super_admin')) {
         throw authorizationError(
-          "Unpublished images can only be accessed by respective owners or super administrators"
+          'Unpublished images can only be accessed by respective owners or super administrators'
         );
       }
-      if (userHasRole(req, "super_admin")) {
+      if (userHasRole(req, 'super_admin')) {
         // no restriction on is_published - get all images whatever status
       } else {
         // get all published images
@@ -285,7 +285,7 @@ const getImages = async (req, orderkey, count = true) => {
   if (query.only_unlocked) {
     whereClauses.push(
       models.sequelize.literal(
-        "last_start IS NULL OR (EXTRACT(EPOCH FROM now())-EXTRACT(EPOCH FROM last_start))/60 >= 240"
+        'last_start IS NULL OR (EXTRACT(EPOCH FROM now())-EXTRACT(EPOCH FROM last_start))/60 >= 240'
       )
     );
   }
@@ -305,7 +305,7 @@ const getImages = async (req, orderkey, count = true) => {
     },
   };
 
-  const randomOrder = models.sequelize.literal("random()");
+  const randomOrder = models.sequelize.literal('random()');
 
   // findAll returns an array where findAndCountAll returns object {rows, count}
   const response = {
@@ -335,19 +335,19 @@ const getImages = async (req, orderkey, count = true) => {
       );
     }
 
-    const orderById = [["id"]];
+    const orderById = [['id']];
     includeOption = [
       {
         model: models.apriori_locations,
         attributes: [
-          [models.sequelize.literal("ST_X(geom)"), "longitude"],
-          [models.sequelize.literal("ST_Y(geom)"), "latitude"],
-          "exact",
+          [models.sequelize.literal('ST_X(geom)'), 'longitude'],
+          [models.sequelize.literal('ST_Y(geom)'), 'latitude'],
+          'exact',
         ],
         where: whereClauseApriori,
         required: true,
         duplicating: false,
-        order: orderBy === "distance" ? orderByApriori : undefined,
+        order: orderBy === 'distance' ? orderByApriori : undefined,
       },
       includeCollectionFilter,
     ];
@@ -358,9 +358,9 @@ const getImages = async (req, orderkey, count = true) => {
       offset: query.offset || 0,
       where: { [Op.and]: whereClauses },
       order:
-        orderBy === "id"
+        orderBy === 'id'
           ? orderById
-          : orderBy === "random"
+          : orderBy === 'random'
           ? randomOrder
           : orderByApriori,
       include: includeOption,
@@ -371,7 +371,7 @@ const getImages = async (req, orderkey, count = true) => {
       const countPromise = await models.images.count({
         where: { [Op.and]: whereClauses },
         include: includeOption,
-        distinct: "images.id",
+        distinct: 'images.id',
       });
       response.count = countPromise;
       return response;
@@ -383,7 +383,7 @@ const getImages = async (req, orderkey, count = true) => {
     const orderByNearest = models.sequelize.literal(
       `images.location <-> st_setsrid(ST_makepoint(${query.longitude}, ${query.latitude}), 4326)`
     );
-    const orderById = [["id"]];
+    const orderById = [['id']];
     const sequelizeQuery = {
       subQuery: false,
       attributes: attributes,
@@ -391,9 +391,9 @@ const getImages = async (req, orderkey, count = true) => {
       offset: query.offset || 0,
       where: { [Op.and]: whereClauses },
       order:
-        orderBy === "distance"
+        orderBy === 'distance'
           ? orderByNearest
-          : orderBy === "random"
+          : orderBy === 'random'
           ? randomOrder
           : orderById,
       include: [includeCollectionFilter],
@@ -416,18 +416,18 @@ const getImagesFromPOI = async (req) => {
   const orderBy = query.sortKey;
   const poiLocationGeo = Sequelize.cast(
     Sequelize.fn(
-      "ST_SetSRID",
-      Sequelize.fn("ST_MakePoint", query.POI_longitude, query.POI_latitude),
+      'ST_SetSRID',
+      Sequelize.fn('ST_MakePoint', query.POI_longitude, query.POI_latitude),
       4326
     ),
-    "geography"
+    'geography'
   );
   const imageLocationGeo = Sequelize.cast(
-    Sequelize.col("images.location"),
-    "geography"
+    Sequelize.col('images.location'),
+    'geography'
   );
   const distanceExpr = Sequelize.fn(
-    "ST_Distance",
+    'ST_Distance',
     imageLocationGeo,
     poiLocationGeo
   );
@@ -507,7 +507,7 @@ const getImagesFromPOI = async (req) => {
   whereClauses.push(
     Sequelize.where(
       Sequelize.fn(
-        "ST_DWithin",
+        'ST_DWithin',
         imageLocationGeo,
         poiLocationGeo,
         query.POI_MaxDistance
@@ -528,11 +528,11 @@ const getImagesFromPOI = async (req) => {
     attributes: attributes,
     where: { [Op.and]: whereClauses },
     order:
-      orderBy === "distance"
+      orderBy === 'distance'
         ? [orderByNearest]
-        : orderBy === "title"
-        ? [["title"]]
-        : [["date_shot_min"]],
+        : orderBy === 'title'
+        ? [['title']]
+        : [['date_shot_min']],
     limit: query.limit || 30,
     offset: query.offset || 0,
   };
@@ -550,7 +550,7 @@ exports.getList = utils.route(async (req, res) => {
     images = await getImages(req);
   }
   //Build media
-  if (!req.query.attributes || req.query.attributes.includes("media")) {
+  if (!req.query.attributes || req.query.attributes.includes('media')) {
     //only return media if no specific attributes requested or if media requested
     if (images.rows) {
       await mediaUtils.setListImageUrl(
@@ -568,8 +568,8 @@ exports.getList = utils.route(async (req, res) => {
 });
 
 exports.getListId = utils.route(async (req, res) => {
-  req.query = { ...req.query, attributes: ["id"] };
-  const images = await getImages(req, /*orderBy*/ "id", /*count*/ false);
+  req.query = { ...req.query, attributes: ['id'] };
+  const images = await getImages(req, /*orderBy*/ 'id', /*count*/ false);
   // Send flattened objects
   res.status(200).send(images.rows.map((obj) => obj.id));
 });
@@ -584,7 +584,7 @@ exports.getListMetadata = utils.route(async (req, res) => {
     // A super administrator can request image metadata for any owner (or access
     // all images).
     ownerIds = requestedOwnerIds;
-  } else if (user.hasRole("owner_admin") || user.hasRole("owner_validator")) {
+  } else if (user.hasRole('owner_admin') || user.hasRole('owner_validator')) {
     // An owner administrator or validator can only request image metadata for
     // their owner.
     const accessibleOwnerIds = [user.owner_id];
@@ -593,14 +593,14 @@ exports.getListMetadata = utils.route(async (req, res) => {
       : accessibleOwnerIds;
     if (requestedOwnerIds && ownerIds.length !== requestedOwnerIds.length) {
       throw authorizationError(
-        "An owner validator or administrator can only access metadata for images linked to the same owner"
+        'An owner validator or administrator can only access metadata for images linked to the same owner'
       );
     }
   } else {
     throw new Error(
       `Cannot determine owner scope for user ${
         user.id
-      } with unsupported role(s) ${user.roles.join(", ")}`
+      } with unsupported role(s) ${user.roles.join(', ')}`
     );
   }
 
@@ -623,37 +623,37 @@ exports.getListMetadata = utils.route(async (req, res) => {
       model: models.geolocalisations,
       attributes: [
         [
-          models.sequelize.literal("st_X(geolocalisation.location)"),
-          "longitude",
+          models.sequelize.literal('st_X(geolocalisation.location)'),
+          'longitude',
         ],
         [
-          models.sequelize.literal("st_Y(geolocalisation.location)"),
-          "latitude",
+          models.sequelize.literal('st_Y(geolocalisation.location)'),
+          'latitude',
         ],
         [
-          models.sequelize.literal("st_Z(geolocalisation.location)"),
-          "altitude",
+          models.sequelize.literal('st_Z(geolocalisation.location)'),
+          'altitude',
         ],
-        "azimuth",
-        "tilt",
-        "roll",
-        "focal",
+        'azimuth',
+        'tilt',
+        'roll',
+        'focal',
         [
-          models.sequelize.literal("st_AsText(geolocalisation.location)"),
-          "point",
+          models.sequelize.literal('st_AsText(geolocalisation.location)'),
+          'point',
         ],
         [
-          models.sequelize.literal("st_AsText(geolocalisation.footprint)"),
-          "footprint",
+          models.sequelize.literal('st_AsText(geolocalisation.footprint)'),
+          'footprint',
         ],
       ],
       where: {
         [Op.and]: [
           {
-            [Op.or]: [{ state: "validated" }, { state: "improved" }],
+            [Op.or]: [{ state: 'validated' }, { state: 'improved' }],
           },
           {
-            id: { [Op.col]: "images.geolocalisation_id" },
+            id: { [Op.col]: 'images.geolocalisation_id' },
           },
         ],
       },
@@ -671,27 +671,27 @@ exports.getListMetadata = utils.route(async (req, res) => {
   });
 
   const attributes = [
-    "id",
-    "original_id",
-    "collection_id",
-    "owner_id",
-    "state",
-    "title",
-    "caption",
-    "link",
-    "is_published",
-    [models.sequelize.literal("ST_X(images.location)"), "longitude"],
-    [models.sequelize.literal("ST_Y(images.location)"), "latitude"],
+    'id',
+    'original_id',
+    'collection_id',
+    'owner_id',
+    'state',
+    'title',
+    'caption',
+    'link',
+    'is_published',
+    [models.sequelize.literal('ST_X(images.location)'), 'longitude'],
+    [models.sequelize.literal('ST_Y(images.location)'), 'latitude'],
   ];
 
   if (req.query.geolocalisation) {
     attributes.push([
-      Sequelize.col("geometadatum.toponyms_array"),
-      "geotags_array",
+      Sequelize.col('geometadatum.toponyms_array'),
+      'geotags_array',
     ]);
     attributes.push([
-      Sequelize.col("geometadatum.toponyms_json"),
-      "geotags_json",
+      Sequelize.col('geometadatum.toponyms_json'),
+      'geotags_json',
     ]);
   }
 
@@ -700,11 +700,11 @@ exports.getListMetadata = utils.route(async (req, res) => {
     limit: req.query.limit || 30,
     offset: req.query.offset || 0,
     where: cleanedWhere,
-    order: [["id"]],
+    order: [['id']],
     include: req.query.geolocalisation ? includeGeoloc : null,
   });
 
-  res.header("Total-Items", countTotal).status(200).send(images);
+  res.header('Total-Items', countTotal).status(200).send(images);
 });
 
 exports.getStats = utils.route(async (req, res) => {
@@ -762,13 +762,13 @@ exports.getStats = utils.route(async (req, res) => {
   const cleanedWhere = cleanProp(whereImages);
 
   const queryPromise = models.images.findAll({
-    attributes: ["state", [models.sequelize.fn("COUNT", "id"), "count"]],
+    attributes: ['state', [models.sequelize.fn('COUNT', 'id'), 'count']],
     where: cleanedWhere,
-    group: ["state"],
+    group: ['state'],
   });
 
   const result = await utils.handlePromise(queryPromise, {
-    message: "Images cannot be retrieved.",
+    message: 'Images cannot be retrieved.',
   });
 
   res.status(200).send({

--- a/db/migrations/20250512103500-add-new-index-location-cast-geography.js
+++ b/db/migrations/20250512103500-add-new-index-location-cast-geography.js
@@ -1,0 +1,17 @@
+"use strict";
+
+module.exports = {
+  up: async (queryInterface) => {
+    await queryInterface.sequelize.query(`
+      CREATE INDEX images_location_geog_idx
+      ON public.images
+      USING GIST ((location::geography));
+    `);
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.sequelize.query(`
+      DROP INDEX IF EXISTS images_location_geog_idx;
+    `);
+  },
+};


### PR DESCRIPTION
in the query we are casting location to geography to compare to query.POI_longitude, query.POI_latitude

Existing index is not used as its not cast as geography 
```
CREATE INDEX images_gix
    ON public.images USING gist
    (location)
    TABLESPACE pg_default;
```

:( my prettier ext made a load of changes i can undo this if you like. My changes are for getImagesFromPOI endpoint only and the new index migration file