### PR TITLE
New api poi images grouped decades

### DIFF
--- a/app/api/images/images.list.controller.js
+++ b/app/api/images/images.list.controller.js
@@ -443,6 +443,8 @@ const getImagesFromPOI = async (req) => {
 
   let whereClauses = [];
 
+  whereClauses.push({ state: 'validated' });
+
   if (query.owner_id) {
     whereClauses.push({ owner_id: inUniqueOrList(query.owner_id) });
   }

--- a/app/api/images/images.openapi.yml
+++ b/app/api/images/images.openapi.yml
@@ -46,6 +46,29 @@
           $ref: "#/components/responses/NotFoundError"
         "422":
           $ref: "#/components/responses/RequestBodyValidationErrors"
+
+/images/poi_stats:
+  get:
+    summary: Get count per decade about geolocalised images at latitude/longitude.
+    description: |-
+      Return the number of geolocalised images per decade at the specified latitude and longitude.
+      The latitude and longitude are specified in the query parameters.
+    operationId: getPoiStats
+    parameters: !include ./images.openapi.params.yml
+    responses:
+      "200":
+        description: Successful request.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ImagePoiStats"
+      "400":
+        $ref: "#/components/responses/RequestParametersValidationErrors"
+      "401":
+        $ref: "#/components/responses/UnauthorizedError"
+      "403":
+        $ref: "#/components/responses/ForbiddenError"
+
 /images/id:
   get:
     summary: List image IDs.

--- a/app/api/images/images.routes.js
+++ b/app/api/images/images.routes.js
@@ -15,6 +15,11 @@ module.exports = () => {
     listController.getList
   );
 
+  router.get("/images/poi_stats",
+    validateDocumentedRequestParametersFor('GET', '/images/poi_stats'),
+    listController.getPoiStats
+  );
+
   // List image IDs.
   router.get("/images/id",
     authenticate({ required: false }),
@@ -109,7 +114,7 @@ module.exports = () => {
   );
 
   // Post a new image.
-    router.post("/images",
+  router.post("/images",
     authenticate(),
     authorize("owner_admin", "super_admin"),
     validateRequestBodyWithJsonSchema('ImagePostRequest'),
@@ -122,7 +127,7 @@ module.exports = () => {
   )
 
   // Update the attributes of an image.
-    router.put("/images/:id/attributes",
+  router.put("/images/:id/attributes",
     authenticate(),
     authorize("owner_admin", "super_admin"),
     validateDocumentedRequestParametersFor('PUT', '/images/{id}/attributes'),

--- a/app/api/images/schemas/image-poi-stats.schema.json
+++ b/app/api/images/schemas/image-poi-stats.schema.json
@@ -1,0 +1,21 @@
+{
+  "$id": "ImagePoiStats",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "decade": {
+        "type": "string",
+        "description": "Decade, like '1910', '1920', etc."
+      },
+      "count": {
+        "type": "integer",
+        "minimum": 1,
+        "description": "Number of images for the given decade"
+      }
+    },
+    "required": ["year", "count"],
+    "additionalProperties": false
+  }
+}

--- a/db/migrations/20250526103500-add-license_type-table-link-images-table.js
+++ b/db/migrations/20250526103500-add-license_type-table-link-images-table.js
@@ -33,12 +33,19 @@ module.exports = {
       FOREIGN KEY (license_type_id)
       REFERENCES public.license_type(id);
     `);
+    await queryInterface.sequelize.query(`
+      CREATE INDEX images_license_type_id_idx
+      ON public.images (license_type_id);
+    `);
   },
 
   down: async (queryInterface) => {
     await queryInterface.sequelize.query(`
       ALTER TABLE public.images
       DROP CONSTRAINT IF EXISTS fk_license_type;
+    `);
+    await queryInterface.sequelize.query(`
+      DROP INDEX IF EXISTS images_license_type_id_idx;
     `);
     await queryInterface.sequelize.query(`
       ALTER TABLE public.images


### PR DESCRIPTION
1. New API to return image count with IDs from a geo point

3. Bug fix on date filters when only min or max is given but not both
  - ex:` ("images"."date_shot_min" IS NOT NULL AND "images"."date_shot_min" >= '1994-01-16' AND "images"."date_shot_min" <= NULL) AND ("images"."date_shot_max" IS NOT NULL AND "images"."date_shot_max" >= '1994-01-16' AND "images"."date_shot_max" <= NULL)`